### PR TITLE
Fix axios header key

### DIFF
--- a/src/services/axios.js
+++ b/src/services/axios.js
@@ -3,7 +3,7 @@ import axios from 'axios';
 export const urlBase = axios.create({
     baseURL: process.env.REACT_APP_URL_BASE,
     headers:{
-        'Contente-type':'application/json',
+        'Content-Type':'application/json',
         'Access-Control-Max-Age':600
     }
 });


### PR DESCRIPTION
## Summary
- correct `Content-Type` header name in axios configuration

## Testing
- `npm test --silent --watchAll=false` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6840708578dc83219632a8ac225de5a5